### PR TITLE
Convert CSS to Sass/Compass

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ by [Nicolas Gallagher](http://nicolasgallagher.com)
 
 ## Standard buttons
 
-To create the default sign-in button, add a class of `btn-auth` and `btn-[service]` (where `[service]` is one of the supported social sign-in services) to any appropriate element (most likely an anchor).
+To create the default sign-in button, add a class of `btn-[service]` (where `[service]` is one of the supported social sign-in services) to any appropriate element (most likely an anchor).
 
-    <a class="btn-auth btn-[service]" href="#">
+    <a class="btn-[service]" href="#">
         Sign in with <b>[service]</b>
     </a>
 
@@ -14,7 +14,7 @@ To create the default sign-in button, add a class of `btn-auth` and `btn-[servic
 
 To create large buttons include an additional class of `large`
 
-    <a class="btn-auth btn-[service] large" href="#">
+    <a class="btn-[service] large" href="#">
         Sign in with <b>[service]</b>
     </a>
 

--- a/auth-buttons.css
+++ b/auth-buttons.css
@@ -1,375 +1,269 @@
-/*
- * Button Object
- */
-
-/*
- * 1. Corrects inability to style clickable 'input' types in iOS
- * 2. Remove excess padding in IE6/7
- * 3. IE6/7 inline-block hack for native block-level elements
- */
-
-.btn-auth {
-    position: relative;
-    display: inline-block;
-    height: 22px;
-    padding: 0 1em;
-    border: 1px solid #999;
-    border-radius: 2px;
-    margin: 0;
-    text-align: center;
-    text-decoration: none;
-    font-size: 14px;
-    line-height: 22px;
-    white-space: nowrap;
-    cursor: pointer;
-    color: #222;
-    background: #fff;
-    -webkit-box-sizing: content-box;
-    -moz-box-sizing: content-box;
-    box-sizing: content-box;
-    /* iOS */
-    -webkit-appearance: none; /* 1 */
-    /* IE6/7 hacks */
-    *overflow: visible;  /* 2 */
-    *display: inline; /* 3 */
-    *zoom: 1; /* 3 */
+.btn-auth, .btn-facebook, .btn-github, .btn-google, .btn-openid, .btn-twitter, .btn-windows, .btn-yahoo {
+  position: relative;
+  display: -moz-inline-box;
+  -moz-box-orient: vertical;
+  display: inline-block;
+  vertical-align: middle;
+  *vertical-align: auto;
+  height: 22px;
+  padding: 0 1em;
+  border: 1px solid #999;
+  -moz-border-radius: 2px;
+  -webkit-border-radius: 2px;
+  -o-border-radius: 2px;
+  -ms-border-radius: 2px;
+  -khtml-border-radius: 2px;
+  border-radius: 2px;
+  margin: 0;
+  text-align: center;
+  text-decoration: none;
+  font-size: 14px;
+  line-height: 22px;
+  white-space: nowrap;
+  cursor: pointer;
+  color: #222;
+  background: #fff;
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+  -ms-box-sizing: content-box;
+  box-sizing: content-box;
+  -webkit-appearance: none;
+  *overflow: visible;
+  *display: inline;
+  *zoom: 1;
 }
-
-.btn-auth:hover,
-.btn-auth:focus,
-.btn-auth:active {
-    text-decoration: none;
+.btn-auth, .btn-facebook, .btn-github, .btn-google, .btn-openid, .btn-twitter, .btn-windows, .btn-yahoo {
+  *display: inline;
 }
-
-.btn-auth:before {
-    content: "";
-    float: left;
-    width: 22px;
-    height: 22px;
-    background: url(auth-icons.png) no-repeat 99px 99px;
+.btn-auth:hover, .btn-facebook:hover, .btn-github:hover, .btn-google:hover, .btn-openid:hover, .btn-twitter:hover, .btn-windows:hover, .btn-yahoo:hover, .btn-auth:focus, .btn-facebook:focus, .btn-github:focus, .btn-google:focus, .btn-openid:focus, .btn-twitter:focus, .btn-windows:focus, .btn-yahoo:focus, .btn-auth:active, .btn-facebook:active, .btn-github:active, .btn-google:active, .btn-openid:active, .btn-twitter:active, .btn-windows:active, .btn-yahoo:active {
+  text-decoration: none;
 }
-
-/*
- * 36px
- */
-
-.btn-auth.large {
-    height: 36px;
-    line-height: 36px;
-    font-size: 20px;
+.btn-auth:before, .btn-facebook:before, .btn-github:before, .btn-google:before, .btn-openid:before, .btn-twitter:before, .btn-windows:before, .btn-yahoo:before {
+  content: "";
+  float: left;
+  width: 22px;
+  height: 22px;
+  background: url("auth-icons.png") no-repeat 99px 99px;
 }
-
-.btn-auth.large:before {
-    width: 36px;
-    height: 36px;
+.btn-auth.large, .large.btn-facebook, .large.btn-github, .large.btn-google, .large.btn-openid, .large.btn-twitter, .large.btn-windows, .large.btn-yahoo {
+  height: 36px;
+  line-height: 36px;
+  font-size: 20px;
 }
-
-/*
- * Remove excess padding and border in FF3+
- */
-
-.btn-auth::-moz-focus-inner {
-    border: 0;
-    padding: 0;
+.btn-auth.large:before, .large.btn-facebook:before, .large.btn-github:before, .large.btn-google:before, .large.btn-openid:before, .large.btn-twitter:before, .large.btn-windows:before, .large.btn-yahoo:before {
+  width: 36px;
+  height: 36px;
 }
-
-
-/* Facebook (extends .btn-auth)
-   ========================================================================== */
+.btn-auth::-moz-focus-inner, .btn-facebook::-moz-focus-inner, .btn-github::-moz-focus-inner, .btn-google::-moz-focus-inner, .btn-openid::-moz-focus-inner, .btn-twitter::-moz-focus-inner, .btn-windows::-moz-focus-inner, .btn-yahoo::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
 
 .btn-facebook {
-    border-color: #29447e;
-    border-bottom-color: #1a356e;
-    color: #fff;
-    background-color: #5872a7;
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#637bad), to(#5872a7));
-    background-image: -webkit-linear-gradient(#637bad, #5872a7);
-    background-image: -moz-linear-gradient(#637bad, #5872a7);
-    background-image: -ms-linear-gradient(#637bad, #5872a7);
-    background-image: -o-linear-gradient(#637bad, #5872a7);
-    background-image: linear-gradient(#637bad, #5872a7);
-    text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
-    -webkit-box-shadow: inset 0 1px 0 #879ac0;
-    box-shadow: inset 0 1px 0 #879ac0;
+  border-color: #29447e;
+  border-bottom-color: #1a356e;
+  color: #fff;
+  background: #5872a7 -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #637bad), color-stop(100%, #5872a7));
+  background: #5872a7 -webkit-linear-gradient(top, #637bad, #5872a7);
+  background: #5872a7 -moz-linear-gradient(top, #637bad, #5872a7);
+  background: #5872a7 -o-linear-gradient(top, #637bad, #5872a7);
+  background: #5872a7 -ms-linear-gradient(top, #637bad, #5872a7);
+  background: #5872a7 linear-gradient(top, #637bad, #5872a7);
+  text-shadow: rgba(0, 0, 0, 0.25) 0 -1px 0;
+  -moz-box-shadow: #879ac0 0 1px 0 inset;
+  -webkit-box-shadow: #879ac0 0 1px 0 inset;
+  -o-box-shadow: #879ac0 0 1px 0 inset;
+  box-shadow: #879ac0 0 1px 0 inset;
 }
-
-.btn-facebook:hover,
-.btn-facebook:focus {
-    background-color: #3b5998;
+.btn-facebook:hover, .btn-facebook:focus {
+  background-color: #3b5998;
 }
-
 .btn-facebook:active {
-    background: #4f6aa3;
-    -webkit-box-shadow: inset 0 1px 0 #45619d;
-    box-shadow: inset 0 1px 0 #45619d;
+  background: #4f6aa3;
+  -moz-box-shadow: #45619d 0 1px 0 inset;
+  -webkit-box-shadow: #45619d 0 1px 0 inset;
+  -o-box-shadow: #45619d 0 1px 0 inset;
+  box-shadow: #45619d 0 1px 0 inset;
 }
-
-/*
- * Icon
- */
-
 .btn-facebook:before {
-    border-right: 1px solid #465f94;
-    margin: 0 1em 0 -1em;
-    background-position: 0 0;
+  border-right: 1px solid #465f94;
+  margin: 0 1em 0 -1em;
+  background-position: 0 0;
 }
-
 .btn-facebook.large:before {
-    background-position: 0 -22px;
+  background-position: 0 -22px;
 }
-
-
-/* GitHub
-   ========================================================================== */
 
 .btn-github {
-    border-color: #d4d4d4;
-    background: #ececec;
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f4f4f4), to(#ececec));
-    background-image: -webkit-linear-gradient(#f4f4f4, #ececec);
-    background-image: -moz-linear-gradient(#f4f4f4, #ececec);
-    background-image: -ms-linear-gradient(#f4f4f4, #ececec);
-    background-image: -o-linear-gradient(#f4f4f4, #ececec);
-    background-image: linear-gradient(#f4f4f4, #ececec);
-    text-shadow: 1px 1px 0 #fff;
+  border-color: #d4d4d4;
+  background: #ececec -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #f4f4f4), color-stop(100%, #ececec));
+  background: #ececec -webkit-linear-gradient(top, #f4f4f4, #ececec);
+  background: #ececec -moz-linear-gradient(top, #f4f4f4, #ececec);
+  background: #ececec -o-linear-gradient(top, #f4f4f4, #ececec);
+  background: #ececec -ms-linear-gradient(top, #f4f4f4, #ececec);
+  background: #ececec linear-gradient(top, #f4f4f4, #ececec);
+  text-shadow: white 1px 1px 0;
 }
-
-.btn-github:hover,
-.btn-github:focus {
-    border-color: #518cc6;
-    border-bottom-color: #2a65a0;
-    color: #fff;
-    background-color: #599bdc;
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#599bdc), to(#3072b3));
-    background-image: -webkit-linear-gradient(#599bdc, #3072b3);
-    background-image: -moz-linear-gradient(#599bdc, #3072b3);
-    background-image: -ms-linear-gradient(#599bdc, #3072b3);
-    background-image: -o-linear-gradient(#599bdc, #3072b3);
-    background-image: linear-gradient(#599bdc, #3072b3);
-    text-shadow: -1px -1px 0 rgba(0,0,0,0.3);
+.btn-github:hover, .btn-github:focus {
+  border-color: #518cc6;
+  border-bottom-color: #2a65a0;
+  color: #fff;
+  background: #599bdc -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #599bdc), color-stop(100%, #3072b3));
+  background: #599bdc -webkit-linear-gradient(top, #599bdc, #3072b3);
+  background: #599bdc -moz-linear-gradient(top, #599bdc, #3072b3);
+  background: #599bdc -o-linear-gradient(top, #599bdc, #3072b3);
+  background: #599bdc -ms-linear-gradient(top, #599bdc, #3072b3);
+  background: #599bdc linear-gradient(top, #599bdc, #3072b3);
+  text-shadow: rgba(0, 0, 0, 0.3) -1px -1px 0;
 }
-
 .btn-github:active {
-    border-color: #2A65A0;
-    border-bottom-color: #518CC6;
-    background: #3072B3;
-    background: -webkit-gradient(linear, 0 0, 0 100%, from(#3072b3), to(#599bdc));
-    background: -webkit-linear-gradient(#3072b3, #599bdc);
-    background: -moz-linear-gradient(#3072b3, #599bdc);
-    background: -ms-linear-gradient(#3072b3, #599bdc);
-    background: -o-linear-gradient(#3072b3, #599bdc);
-    background: linear-gradient(#3072b3, #599bdc);
+  border-color: #2a65a0;
+  border-bottom-color: #518cc6;
+  background: #3072b3 -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #3072b3), color-stop(100%, #599bdc));
+  background: #3072b3 -webkit-linear-gradient(top, #3072b3, #599bdc);
+  background: #3072b3 -moz-linear-gradient(top, #3072b3, #599bdc);
+  background: #3072b3 -o-linear-gradient(top, #3072b3, #599bdc);
+  background: #3072b3 -ms-linear-gradient(top, #3072b3, #599bdc);
+  background: #3072b3 linear-gradient(top, #3072b3, #599bdc);
 }
-
-/*
- * Icon
- */
-
 .btn-github:before {
-    margin: 0 0.6em 0 -0.6em;
-    background-position: -44px 0;
+  margin: 0 0.6em 0 -0.6em;
+  background-position: -44px 0;
 }
-
-.btn-github:hover:before,
-.btn-github:focus:before,
-.btn-github:active:before {
-    background-position: -66px 0;
+.btn-github:hover:before, .btn-github:focus:before, .btn-github:active:before {
+  background-position: -66px 0;
 }
-
 .btn-github.large:before {
-    background-position: -72px -22px;
+  background-position: -72px -22px;
 }
-
-.btn-github.large:hover:before,
-.btn-github.large:focus:before,
-.btn-github.large:active:before {
-    background-position: -108px -22px;
+.btn-github.large:hover:before, .btn-github.large:focus:before, .btn-github.large:active:before {
+  background-position: -108px -22px;
 }
-
-
-/* Google
-   ========================================================================== */
 
 .btn-google {
-    border-color: #3079ed;
-    color: #fff;
-    background: #4787ed;
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#4d90fe), to(#4787ed));
-    background-image: -webkit-linear-gradient(#4d90fe, #4787ed);
-    background-image: -moz-linear-gradient(#4d90fe, #4787ed);
-    background-image: -ms-linear-gradient(#4d90fe, #4787ed);
-    background-image: -o-linear-gradient(#4d90fe, #4787ed);
-    background-image: linear-gradient(#4d90fe, #4787ed);
-    text-shadow: 0 1px rgba(0,0,0,0.1);
+  border-color: #3079ed;
+  color: #fff;
+  background: #4787ed -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #4d90fe), color-stop(100%, #4787ed));
+  background: #4787ed -webkit-linear-gradient(top, #4d90fe, #4787ed);
+  background: #4787ed -moz-linear-gradient(top, #4d90fe, #4787ed);
+  background: #4787ed -o-linear-gradient(top, #4d90fe, #4787ed);
+  background: #4787ed -ms-linear-gradient(top, #4d90fe, #4787ed);
+  background: #4787ed linear-gradient(top, #4d90fe, #4787ed);
+  text-shadow: rgba(0, 0, 0, 0.1) 0 1px;
 }
-
-.btn-google:hover,
-.btn-google:focus {
-    background-color: #357ae8;
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#4d90fe), to(#357ae8));
-    background-image: -webkit-linear-gradient(#4d90fe, #357ae8);
-    background-image: -moz-linear-gradient(#4d90fe, #357ae8);
-    background-image: -ms-linear-gradient(#4d90fe, #357ae8);
-    background-image: -o-linear-gradient(#4d90fe, #357ae8);
-    background-image: linear-gradient(#4d90fe, #357ae8);
-    text-shadow: 0 1px rgba(0,0,0,0.3);
+.btn-google:hover, .btn-google:focus {
+  background: #357ae8 -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #4d90fe), color-stop(100%, #357ae8));
+  background: #357ae8 -webkit-linear-gradient(top, #4d90fe, #357ae8);
+  background: #357ae8 -moz-linear-gradient(top, #4d90fe, #357ae8);
+  background: #357ae8 -o-linear-gradient(top, #4d90fe, #357ae8);
+  background: #357ae8 -ms-linear-gradient(top, #4d90fe, #357ae8);
+  background: #357ae8 linear-gradient(top, #4d90fe, #357ae8);
+  text-shadow: rgba(0, 0, 0, 0.3) 0 1px;
 }
-
 .btn-google:active {
-    -webkit-box-shadow: inset 0 1px 2px rgba(0,0,0,0.3);
-    box-shadow: inset 0 1px 2px rgba(0,0,0,0.3);
+  -moz-box-shadow: rgba(0, 0, 0, 0.3) 0 1px 2px;
+  -webkit-box-shadow: rgba(0, 0, 0, 0.3) 0 1px 2px;
+  -o-box-shadow: rgba(0, 0, 0, 0.3) 0 1px 2px;
+  box-shadow: rgba(0, 0, 0, 0.3) 0 1px 2px;
 }
-
-/*
- * Icon
- */
-
 .btn-google:before {
-    margin: 0 1em 0 -1em;
-    background-position: -88px 0;
-    background-color: #e6e6e6;
+  margin: 0 1em 0 -1em;
+  background-position: -88px 0;
+  background-color: #e6e6e6;
 }
-
 .btn-google.large:before {
-    background-position: -144px -22px;
+  background-position: -144px -22px;
 }
 
-
-/* Open ID
-   ========================================================================== */
-
-.btn-openid:hover,
-.btn-openid:focus {
-    border-color: #777;
-    background: #fcfcfc;
+.btn-openid:hover, .btn-openid:focus {
+  border-color: #777;
+  background: #fcfcfc;
 }
-
 .btn-openid:active {
-    background: #f5f5f5;
+  background: #f5f5f5;
 }
-
-/*
- * Icon
- */
-
 .btn-openid:before {
-    margin: 0 0.6em 0 -0.6em;
-    background-position: -154px 0;
+  margin: 0 0.6em 0 -0.6em;
+  background-position: -154px 0;
 }
-
 .btn-openid.large:before {
-    background-position: -252px -22px;
+  background-position: -252px -22px;
 }
-
-
-/* Twitter
-   ========================================================================== */
 
 .btn-twitter {
-    border-color: #a6cde6;
-    color: #327695;
-    background: #cfe4f0;
-    /* css3 */
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f1f5f7), to(rgba(255,255,255,0)));
-    background-image: -webkit-linear-gradient(#f1f5f7, rgba(255,255,255,0));
-    background-image: -moz-linear-gradient(#f1f5f7, rgba(255,255,255,0));
-    background-image: -ms-linear-gradient(#f1f5f7, rgba(255,255,255,0));
-    background-image: -o-linear-gradient(#f1f5f7, rgba(255,255,255,0));
-    background-image: linear-gradient(#f1f5f7, rgba(255,255,255,0));
-    text-shadow: 1px 0 0 #bcd3df;
-    -webkit-box-shadow: inset 0 1px 0 #fff;
-    box-shadow: inset 0 1px 0 #fff;
+  border-color: #a6cde6;
+  color: #327695;
+  background: #cfe4f0 -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #f1f5f7), color-stop(100%, rgba(255, 255, 255, 0)));
+  background: #cfe4f0 -webkit-linear-gradient(top, #f1f5f7, rgba(255, 255, 255, 0));
+  background: #cfe4f0 -moz-linear-gradient(top, #f1f5f7, rgba(255, 255, 255, 0));
+  background: #cfe4f0 -o-linear-gradient(top, #f1f5f7, rgba(255, 255, 255, 0));
+  background: #cfe4f0 -ms-linear-gradient(top, #f1f5f7, rgba(255, 255, 255, 0));
+  background: #cfe4f0 linear-gradient(top, #f1f5f7, rgba(255, 255, 255, 0));
+  text-shadow: #bcd3df 1px 0 0;
+  -moz-box-shadow: white 0 1px 0 inset;
+  -webkit-box-shadow: white 0 1px 0 inset;
+  -o-box-shadow: white 0 1px 0 inset;
+  box-shadow: white 0 1px 0 inset;
 }
-
-.btn-twitter:hover,
-.btn-twitter:focus {
-    border-color: #8dc2e4;
-    background-color: #cadde9;
+.btn-twitter:hover, .btn-twitter:focus {
+  border-color: #8dc2e4;
+  background-color: #cadde9;
 }
-
 .btn-twitter:active {
-    background: #cadde9;
-    -webkit-box-shadow: inset 0 1px 0 #bbd6e7;
-    box-shadow: inset 0 1px 0 #bbd6e7;
+  background: #cadde9;
+  -moz-box-shadow: #bbd6e7 0 1px 0 inset;
+  -webkit-box-shadow: #bbd6e7 0 1px 0 inset;
+  -o-box-shadow: #bbd6e7 0 1px 0 inset;
+  box-shadow: #bbd6e7 0 1px 0 inset;
 }
-
-/*
- * Icon
- */
-
 .btn-twitter:before {
-    margin: 0 0.6em 0 -0.6em;
-    background-position: -22px 0;
+  margin: 0 0.6em 0 -0.6em;
+  background-position: -22px 0;
 }
-
 .btn-twitter.large:before {
-    background-position: -36px -22px;
+  background-position: -36px -22px;
 }
 
-
-/* Windows Live ID
-   ========================================================================== */
-
-.btn-windows:hover,
-.btn-windows:focus {
-    border-color: #777;
-    background: #fcfcfc;
+.btn-windows:hover, .btn-windows:focus {
+  border-color: #777;
+  background: #fcfcfc;
 }
-
 .btn-windows:active {
-    background: #f5f5f5;
+  background: #f5f5f5;
 }
-
-/*
- * Icon
- */
-
 .btn-windows:before {
-    margin: 0 0.6em 0 -0.6em;
-    background-position: -110px 0;
+  margin: 0 0.6em 0 -0.6em;
+  background-position: -110px 0;
 }
-
 .btn-windows.large:before {
-    background-position: -180px -22px;
+  background-position: -180px -22px;
 }
-
-
-/* Yahoo!
-   ========================================================================== */
 
 .btn-yahoo {
-    border-color: #ffb305;
-    background: #ffc426;
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(255,255,255,0.5)), to(rgba(255,255,255,0)));
-    background-image: -webkit-linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0));
-    background-image: -moz-linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0));
-    background-image: -ms-linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0));
-    background-image: -o-linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0));
-    background-image: linear-gradient(rgba(255,255,255,0.5), rgba(255,255,255,0));
-    text-shadow: -1px -1px 0 rgba(0,0,0,0.1);
+  border-color: #ffb305;
+  background: #ffc426 -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, rgba(255, 255, 255, 0.5)), color-stop(100%, rgba(255, 255, 255, 0)));
+  background: #ffc426 -webkit-linear-gradient(top, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0));
+  background: #ffc426 -moz-linear-gradient(top, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0));
+  background: #ffc426 -o-linear-gradient(top, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0));
+  background: #ffc426 -ms-linear-gradient(top, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0));
+  background: #ffc426 linear-gradient(top, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0));
+  text-shadow: rgba(0, 0, 0, 0.1) -1px -1px 0;
 }
-
-.btn-yahoo:hover,
-.btn-yahoo:focus {
-    background-color: #fabf20;
+.btn-yahoo:hover, .btn-yahoo:focus {
+  background-color: #fabf20;
 }
-
 .btn-yahoo:active {
-    border-color: #f09700;
-    background-image: none;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.3);
-    box-shadow: inset 0 1px 1px rgba(0,0,0,0.3);
+  border-color: #f09700;
+  background-image: none;
+  -moz-box-shadow: rgba(0, 0, 0, 0.3) 0 1px 1px inset;
+  -webkit-box-shadow: rgba(0, 0, 0, 0.3) 0 1px 1px inset;
+  -o-box-shadow: rgba(0, 0, 0, 0.3) 0 1px 1px inset;
+  box-shadow: rgba(0, 0, 0, 0.3) 0 1px 1px inset;
 }
-
-/*
- * Icon
- */
-
 .btn-yahoo:before {
-    margin: 0 0.6em 0 -0.6em;
-    background-position: -132px 0;
+  margin: 0 0.6em 0 -0.6em;
+  background-position: -132px 0;
 }
-
 .btn-yahoo.large:before {
-    background-position: -216px -22px;
+  background-position: -216px -22px;
 }

--- a/auth-buttons.scss
+++ b/auth-buttons.scss
@@ -1,0 +1,279 @@
+// To compile this to CSS:
+//     $ gem install compass
+//     $ sass --style expanded --compass auth-buttons.scss:auth-buttons.css
+
+@import "compass";
+
+.btn-auth {
+    position: relative;
+    @include inline-block;
+    height: 22px;
+    padding: 0 1em;
+    border: 1px solid #999;
+    @include border-radius(2px);
+    margin: 0;
+    text-align: center;
+    text-decoration: none;
+    font-size: 14px;
+    line-height: 22px;
+    white-space: nowrap;
+    cursor: pointer;
+    color: #222;
+    background: #fff;
+    @include box-sizing(content-box);
+    // iOS
+    -webkit-appearance: none;
+    // IE6/7 hacks
+    *overflow: visible;
+    *display: inline;
+    *zoom: 1;
+    
+    &:hover,
+    &:focus,
+    &:active {
+        text-decoration: none;
+    }
+    
+    &:before {
+        content: "";
+        float: left;
+        width: 22px;
+        height: 22px;
+        background: url("auth-icons.png") no-repeat 99px 99px;
+    }
+    
+    // 36px
+    &.large {
+        height: 36px;
+        line-height: 36px;
+        font-size: 20px;
+    }
+    
+    &.large:before {
+        width: 36px;
+        height: 36px;
+    }
+    
+    // Remove excess padding and border in FF3+
+    &::-moz-focus-inner {
+        border: 0;
+        padding: 0;
+    }
+}
+
+// Facebook
+.btn-facebook {
+    @extend .btn-auth;
+    border-color: #29447e;
+    border-bottom-color: #1a356e;
+    color: #fff;
+    @include background(#5872a7 linear-gradient(top, #637bad, #5872a7));
+    @include text-shadow(rgba(0, 0, 0, 0.25) 0 -1px 0);
+    @include box-shadow(#879ac0 0 1px 0 inset);
+    
+    &:hover,
+    &:focus {
+        background-color: #3b5998;
+    }
+    
+    &:active {
+        background: #4f6aa3;
+        @include box-shadow(#45619d 0 1px 0 inset);
+    }
+    
+    // Icon
+    &:before {
+        border-right: 1px solid #465f94;
+        margin: 0 1em 0 -1em;
+        background-position: 0 0;
+    }
+    
+    &.large:before {
+        background-position: 0 -22px;
+    }
+}
+
+// GitHub
+.btn-github {
+    @extend .btn-auth;
+    border-color: #d4d4d4;
+    @include background(#ececec linear-gradient(top, #f4f4f4, #ececec));
+    @include text-shadow(#fff 1px 1px 0);
+    
+    &:hover,
+    &:focus {
+        border-color: #518cc6;
+        border-bottom-color: #2a65a0;
+        color: #fff;
+        @include background(#599bdc linear-gradient(top, #599bdc, #3072b3));
+        @include text-shadow(rgba(0,0,0,0.3) -1px -1px 0);
+    }
+    
+    &:active {
+        border-color: #2a65a0;
+        border-bottom-color: #518cc6;
+        @include background(#3072b3 linear-gradient(top, #3072b3, #599bdc));
+    }
+    
+    // Icon
+    &:before {
+        margin: 0 0.6em 0 -0.6em;
+        background-position: -44px 0;
+    }
+    
+    &:hover:before,
+    &:focus:before,
+    &:active:before {
+        background-position: -66px 0;
+    }
+    
+    &.large:before {
+        background-position: -72px -22px;
+    }
+    
+    &.large:hover:before,
+    &.large:focus:before,
+    &.large:active:before {
+        background-position: -108px -22px;
+    }
+}
+
+// Google
+.btn-google {
+    @extend .btn-auth;
+    border-color: #3079ed;
+    color: #fff;
+    @include background(#4787ed linear-gradient(top, #4d90fe, #4787ed));
+    @include text-shadow(rgba(0,0,0,0.1) 0 1px);
+    
+    &:hover,
+    &:focus {
+        @include background(#357ae8 linear-gradient(top, #4d90fe, #357ae8));
+        @include text-shadow(rgba(0,0,0,0.3) 0 1px);
+    }
+    
+    &:active {
+        @include box-shadow(rgba(0,0,0,0.3) 0 1px 2px);
+    }
+    
+    // Icon
+    &:before {
+        margin: 0 1em 0 -1em;
+        background-position: -88px 0;
+        background-color: #e6e6e6;
+    }
+    
+    &.large:before {
+        background-position: -144px -22px;
+    }
+}
+
+// Open ID
+.btn-openid {
+    @extend .btn-auth;
+    
+    &:hover,
+    &:focus {
+        border-color: #777;
+        background: #fcfcfc;
+    }
+    
+    &:active {
+        background: #f5f5f5;
+    }
+    
+    // Icon
+    &:before {
+        margin: 0 0.6em 0 -0.6em;
+        background-position: -154px 0;
+    }
+    
+    &.large:before {
+        background-position: -252px -22px;
+    }
+}
+
+// Twitter
+.btn-twitter {
+    @extend .btn-auth;
+    border-color: #a6cde6;
+    color: #327695;
+    @include background(#cfe4f0 linear-gradient(top, #f1f5f7, rgba(255,255,255,0)));
+    @include text-shadow(#bcd3df 1px 0 0);
+    @include box-shadow(#fff 0 1px 0 inset);
+    
+    &:hover,
+    &:focus {
+        border-color: #8dc2e4;
+        background-color: #cadde9;
+    }
+    
+    &:active {
+        background: #cadde9;
+        @include box-shadow(#bbd6e7 0 1px 0 inset);
+    }
+    
+    // Icon
+    &:before {
+        margin: 0 0.6em 0 -0.6em;
+        background-position: -22px 0;
+    }
+    
+    &.large:before {
+        background-position: -36px -22px;
+    }
+}
+
+// Windows Live ID
+.btn-windows {
+    @extend .btn-auth;
+    
+    &:hover,
+    &:focus {
+        border-color: #777;
+        background: #fcfcfc;
+    }
+    
+    &:active {
+        background: #f5f5f5;
+    }
+    
+    // Icon
+    &:before {
+        margin: 0 0.6em 0 -0.6em;
+        background-position: -110px 0;
+    }
+    
+    &.large:before {
+        background-position: -180px -22px;
+    }
+}
+
+// Yahoo!
+.btn-yahoo {
+    @extend .btn-auth;
+    border-color: #ffb305;
+    @include background(#ffc426 linear-gradient(top, rgba(255,255,255,0.5), rgba(255,255,255,0)));
+    @include text-shadow(rgba(0,0,0,0.1) -1px -1px 0);
+    
+    &:hover,
+    &:focus {
+        background-color: #fabf20;
+    }
+    
+    &:active {
+        border-color: #f09700;
+        background-image: none;
+        @include box-shadow(rgba(0,0,0,0.3) 0 1px 1px inset);
+    }
+    
+    // Icon
+    &:before {
+        margin: 0 0.6em 0 -0.6em;
+        background-position: -132px 0;
+    }
+    
+    &.large:before {
+        background-position: -216px -22px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     
     <div class="section">
         <h2>Standard Buttons</h2>
-        <p>To create the default sign-in button, add a class of <code>btn-auth</code> and <code>btn-[service]</code> (where <code>[service]</code> is one of the supported social sign-in services) to any appropriate element (most likely an anchor).</p>
+        <p>To create the default sign-in button, add a class of <code>btn-[service]</code> (where <code>[service]</code> is one of the supported social sign-in services) to any appropriate element (most likely an anchor).</p>
 
         <div class="example">
             <pre class="prettyprint"><code>&lt;a class="btn-[service]" href="#">

--- a/index.html
+++ b/index.html
@@ -77,17 +77,17 @@
         <p>To create the default sign-in button, add a class of <code>btn-auth</code> and <code>btn-[service]</code> (where <code>[service]</code> is one of the supported social sign-in services) to any appropriate element (most likely an anchor).</p>
 
         <div class="example">
-            <pre class="prettyprint"><code>&lt;a class="btn-auth btn-[service]" href="#">
+            <pre class="prettyprint"><code>&lt;a class="btn-[service]" href="#">
     Sign in with &lt;b>[service]&lt;/b>
 &lt;/a></code></pre>
             <div>
-                <p><a class="btn-auth btn-facebook" href="#button">Sign in with <b>Facebook</b></a></p>
-                <p><a class="btn-auth btn-twitter" href="#button">Sign in with <b>Twitter</b></a></p>
-                <p><a class="btn-auth btn-google" href="#button">Sign in with <b>Google</b></a></p>
-                <p><a class="btn-auth btn-github" href="#button">Sign in with <b>GitHub</b></a></p>
-                <p><a class="btn-auth btn-yahoo" href="#button">Sign in with <b>Yahoo!</b></a></p>
-                <p><a class="btn-auth btn-windows" href="#button">Sign in with <b>Windows Live ID</b></a></p>
-                <p><a class="btn-auth btn-openid" href="#button">Sign in with <b>OpenID</b></a></p>
+                <p><a class="btn-facebook" href="#button">Sign in with <b>Facebook</b></a></p>
+                <p><a class="btn-twitter" href="#button">Sign in with <b>Twitter</b></a></p>
+                <p><a class="btn-google" href="#button">Sign in with <b>Google</b></a></p>
+                <p><a class="btn-github" href="#button">Sign in with <b>GitHub</b></a></p>
+                <p><a class="btn-yahoo" href="#button">Sign in with <b>Yahoo!</b></a></p>
+                <p><a class="btn-windows" href="#button">Sign in with <b>Windows Live ID</b></a></p>
+                <p><a class="btn-openid" href="#button">Sign in with <b>OpenID</b></a></p>
             </div>
         </div>
     </div>
@@ -97,17 +97,17 @@
         <p>To create larger buttons include an additional class of <code>large</code>.</p>
         
         <div class="example">
-            <pre class="prettyprint"><code>&lt;a class="btn-auth btn-[service] large" href="#">
+            <pre class="prettyprint"><code>&lt;a class="btn-[service] large" href="#">
     Sign in with &lt;b>[service]&lt;/b>
 &lt;/a></code></pre>
             <div>
-                <p><a class="btn-auth btn-facebook large" href="#button">Sign in with <b>Facebook</b></a></p>
-                <p><a class="btn-auth btn-twitter large" href="#button">Sign in with <b>Twitter</b></a></p>
-                <p><a class="btn-auth btn-google large" href="#button">Sign in with <b>Google</b></a></p>
-                <p><a class="btn-auth btn-github large" href="#button">Sign in with <b>GitHub</b></a></p>
-                <p><a class="btn-auth btn-yahoo large" href="#button">Sign in with <b>Yahoo!</b></a></p>
-                <p><a class="btn-auth btn-windows large" href="#button">Sign in with <b>Windows Live ID</b></a></p>
-                <p><a class="btn-auth btn-openid large" href="#button">Sign in with <b>OpenID</b></a></p>
+                <p><a class="btn-facebook large" href="#button">Sign in with <b>Facebook</b></a></p>
+                <p><a class="btn-twitter large" href="#button">Sign in with <b>Twitter</b></a></p>
+                <p><a class="btn-google large" href="#button">Sign in with <b>Google</b></a></p>
+                <p><a class="btn-github large" href="#button">Sign in with <b>GitHub</b></a></p>
+                <p><a class="btn-yahoo large" href="#button">Sign in with <b>Yahoo!</b></a></p>
+                <p><a class="btn-windows large" href="#button">Sign in with <b>Windows Live ID</b></a></p>
+                <p><a class="btn-openid large" href="#button">Sign in with <b>OpenID</b></a></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Hi,

I converted your CSS to [Sass](http://sass-lang.com/)/[Compass](http://compass-style.org/). In my view this has a lot of advantages: it's more compatible, nicer to read, better to extend and it allows us to drop the `.btn-auth` class requirement because of Compass' awesome `@extend` statement.

To compile the `.scss` file to `.css`:

```
 $ gem install compass
 $ sass --style expanded --compass auth-buttons.scss:auth-buttons.css
```
